### PR TITLE
Ht 97/events integration

### DIFF
--- a/src/app/(frontend)/events/page.tsx
+++ b/src/app/(frontend)/events/page.tsx
@@ -1,6 +1,3 @@
-'use client'
-
-import { useState } from 'react'
 import Header from '@/components/common/Header'
 import Footer from '@/components/common/Footer'
 import Hero from '@/components/events/Hero'
@@ -8,16 +5,18 @@ import EventsSignUpModal from '@/components/events/EventsSignUpModal'
 import RecentEvents from '@/components/events/RecentEvents'
 import PastEventsSection from '@/components/events/PastEventsSection'
 import PastEventsPopUpModal from '@/components/events/PastEventsPopUpModal'
+import {getPastEvents, getUpcomingEvents} from "@/lib/payload/events";
 
-export default function EventsPage() {
-  const [signOpen, setSignOpen] = useState(false)
+export default async function EventsPage() {
+  const upcoming = await getUpcomingEvents()
+  const past = await getPastEvents()
 
   return (
     <div className="home">
       <Header />
       <Hero />
-      <RecentEvents />
-      {/*<PastEventsSection />*/}
+      <RecentEvents initialEvents={upcoming}/>
+      <PastEventsSection initialEvents={past}/>
       <Footer />
       <EventsSignUpModal signOpen={signOpen} setSignOpen={setSignOpen} />
       <PastEventsPopUpModal

--- a/src/app/(frontend)/events/page.tsx
+++ b/src/app/(frontend)/events/page.tsx
@@ -18,13 +18,6 @@ export default async function EventsPage() {
       <RecentEvents initialEvents={upcoming}/>
       <PastEventsSection initialEvents={past}/>
       <Footer />
-      <EventsSignUpModal signOpen={signOpen} setSignOpen={setSignOpen} />
-      <PastEventsPopUpModal
-        signOpen={signOpen}
-        setSignOpen={setSignOpen}
-        events={[]}
-        initialIdx={0}
-      />
     </div>
   )
 }

--- a/src/app/(frontend)/events/page.tsx
+++ b/src/app/(frontend)/events/page.tsx
@@ -17,7 +17,7 @@ export default function EventsPage() {
       <Header />
       <Hero />
       <RecentEvents />
-      <PastEventsSection />
+      {/*<PastEventsSection />*/}
       <Footer />
       <EventsSignUpModal signOpen={signOpen} setSignOpen={setSignOpen} />
       <PastEventsPopUpModal

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,6 +1,0 @@
-import { NextResponse } from 'next/server'
-import events from '@/data/events.json'
-
-export async function GET() {
-  return NextResponse.json(events)
-}

--- a/src/app/api/upcoming-events/route.ts
+++ b/src/app/api/upcoming-events/route.ts
@@ -1,6 +1,0 @@
-import { NextResponse } from 'next/server'
-import upcomingEvents from '@/data/upcomingEvents.json'
-
-export async function GET() {
-  return NextResponse.json(upcomingEvents)
-}

--- a/src/collections/Events.ts
+++ b/src/collections/Events.ts
@@ -25,6 +25,7 @@ export const Events: CollectionConfig = {
     {
       name: 'date',
       type: 'date',
+      required: true,
       admin: {
         date: {
           pickerAppearance: 'dayAndTime',

--- a/src/components/events/EventsCard.tsx
+++ b/src/components/events/EventsCard.tsx
@@ -1,18 +1,7 @@
 import Image from 'next/image'
 import KiwiBird from '@/assets/kiwiBird.svg'
 import PlaceholderImg from '@/assets/event-pic.png'
-
-type EventType = {
-  id: string
-  name: string
-  hosted_by: string
-  description: string
-  date_range: {
-    start: string
-    end: string
-  }
-  image?: string
-}
+import type { EventType } from '@/types/event'
 
 export default function EventsCard({
   event,
@@ -24,21 +13,21 @@ export default function EventsCard({
   return (
     <div className="flex flex-col justify-center items-center w-70 h-90 border-4 border-[#13384E] rounded-xl gap-y-2 px-4 bg-[#FFF8F3]">
       <div className="relative flex justify-center items-center">
-        <h3 className="text-2xl">{event.name}</h3>
+        <h3 className="text-2xl">{event.title}</h3>
         <Image src={KiwiBird} alt="kiwi-bird" width={40} className="absolute top-0 left-35" />
       </div>
 
       <div className="flex flex-col justify-center items-center gap-y-2">
         <div className="relative flex justify-center items-center">
           <Image
-            src={event.image || PlaceholderImg}
-            alt={event.name}
+            src={event.imageUrl}
+            alt={event.title}
             width={210}
             height={140}
             className="w-[210px] h-[140px] object-cover rounded-lg"
           />
           <p className="absolute text-xs rotate-270 right-40 whitespace-nowrap">
-            HOSTED BY: {event.hosted_by}
+            HOSTED BY: {event.hostedBy}
           </p>
         </div>
         <p className="text-xs">{event.description}</p>

--- a/src/components/events/PastEventsGrid.tsx
+++ b/src/components/events/PastEventsGrid.tsx
@@ -1,18 +1,10 @@
+'use client'
+
 import EventsCard from './EventsCard'
 import PastEventsPopUpModal from './PastEventsPopUpModal'
 import { useState } from 'react'
-
-type EventType = {
-  id: string
-  name: string
-  hosted_by: string
-  description: string
-  date_range: {
-    start: string
-    end: string
-  }
-  image?: string
-}
+import { EventType } from '@/types/event'
+import Image from 'next/image'
 
 export default function PastEvents({ events }: { events: EventType[] }) {
   const [signOpen, setSignOpen] = useState(false)

--- a/src/components/events/PastEventsGrid.tsx
+++ b/src/components/events/PastEventsGrid.tsx
@@ -39,6 +39,6 @@ export default function PastEvents({ events }: { events: EventType[] }) {
         events={events}
         initialIdx={selectedIdx}
       />
-    </>
+    </div>
   )
 }

--- a/src/components/events/PastEventsPopUpModal.tsx
+++ b/src/components/events/PastEventsPopUpModal.tsx
@@ -5,18 +5,7 @@ import blurWave from '@/assets/blur_blue_wave.png'
 import placeholder1 from '@/assets/landscape_placeholder.png'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
-
-type EventType = {
-  id: string
-  name: string
-  hosted_by: string
-  description: string
-  date_range: {
-    start: string
-    end: string
-  }
-  image?: string
-}
+import type { EventType } from '@/types/event'
 
 export default function PastEventsPopUpModal({
   signOpen,
@@ -40,7 +29,7 @@ export default function PastEventsPopUpModal({
   const goNext = () => setCurrentIdx((prev) => (prev === events.length - 1 ? 0 : prev + 1))
 
   const event = events[currentIdx]
-  const imageSrc = event?.image || placeholder1
+  const imageSrc = event?.imageUrl
 
   return (
     <Modal
@@ -55,16 +44,16 @@ export default function PastEventsPopUpModal({
         <Image src={blurWave} alt="Blurred Wave" fill className="object-cover w-full h-full" />
         <div className="absolute top-10">
           <p className="text-lg text-black font-bold" style={{ fontFamily: 'var(--font-header)' }}>
-            {event?.name}
+            {event?.title}
           </p>
         </div>
         <div className="absolute top-17">
           <p className="text-xs text-black font-bold" style={{ fontFamily: 'var(--font-header)' }}>
-            {event
-              ? `${new Date(event.date_range.start).toLocaleDateString()} - ${new Date(
-                  event.date_range.end,
-                ).toLocaleDateString()}`
-              : ''}
+            {event.date.toLocaleDateString('en-NZ', {
+              day: 'numeric',
+              month: 'long',
+              year: 'numeric',
+            })}
           </p>
         </div>
         <div className="max-w-7xl relative rounded-3xl overflow-hidden z-20 pb-15 pt-20">
@@ -75,7 +64,7 @@ export default function PastEventsPopUpModal({
             <div className="relative w-60 h-46 rounded-xl overflow-hidden shadow-md md:w-70 md:h-56 lg:w-80 lg:h-60 xl:w-90 xl:h-66">
               <Image
                 src={imageSrc}
-                alt={event?.name || 'Event image'}
+                alt={event?.title || 'Event image'}
                 className="w-full h-full object-cover"
                 width={320}
                 height={224}

--- a/src/components/events/PastEventsSection.tsx
+++ b/src/components/events/PastEventsSection.tsx
@@ -1,29 +1,10 @@
-import { useEffect, useState } from 'react'
 import YearFilter from '@/components/events/YearFilter'
 import PastEvents from '@/components/events/PastEventsGrid'
 import Image from 'next/image'
 import BlueKoru from '@/assets/blue_koru.png'
+import type { EventType } from '@/types/event'
 
-type EventType = {
-  id: string
-  name: string
-  hosted_by: string
-  description: string
-  date_range: {
-    start: string
-    end: string
-  }
-  image?: string
-}
-
-export default function PastEventsSection() {
-  const [events, setEvents] = useState<EventType[]>([])
-
-  useEffect(() => {
-    fetch('/api/events')
-      .then((res) => res.json())
-      .then((data) => setEvents(data.events))
-  }, [])
+export default function PastEventsSection({ initialEvents, }: { initialEvents: EventType[] }) {
 
   return (
     <div className="w-full max-w-full relative py-50">
@@ -37,7 +18,7 @@ export default function PastEventsSection() {
       </h3>
       <div className="bg-[#E6E1DE] flex flex-col items-center gap-y-10 py-10">
         <YearFilter />
-        <PastEvents events={events} />
+        <PastEvents events={initialEvents} />
       </div>
     </div>
   )

--- a/src/components/events/RecentEvents.tsx
+++ b/src/components/events/RecentEvents.tsx
@@ -3,23 +3,16 @@ import {useState, useEffect} from 'react'
 import Image from 'next/image'
 import SignUpModal from '@/components/events/EventsSignUpModal'
 import Koru from '@/assets/recent_events_koru.png'
-import placeholderImage from '@/assets/groupPic.png'
 import KiwiBird from '@/assets/kiwiBird.svg'
 import {Kosugi_Maru} from 'next/font/google'
-import {getUpcomingEvents} from "@/lib/payload/events";
 import type { EventType } from '@/types/event'
 
 const kosugiMaru = Kosugi_Maru({subsets: ['latin'], weight: '400'})
 
-export default function RecentEvents() {
+export default function RecentEvents({ initialEvents }: { initialEvents: EventType[] }) {
   const [signOpen, setSignOpen] = useState(false)
-  const [events, setEvents] = useState<EventType[]>([])
-
-  useEffect(() => {
-    getUpcomingEvents().then(setEvents)
-  }, [])
-
-  const eventNames = events.map((event) => event.title)
+  const events = initialEvents
+  const eventNames = events.map(e => e.title)
 
   return (
     <>

--- a/src/components/events/RecentEvents.tsx
+++ b/src/components/events/RecentEvents.tsx
@@ -7,17 +7,16 @@ import placeholderImage from '@/assets/groupPic.png'
 import KiwiBird from '@/assets/kiwiBird.svg'
 import {Kosugi_Maru} from 'next/font/google'
 import {getUpcomingEvents} from "@/lib/payload/events";
-import type {Event} from '@/payload-types'
+import type { EventType } from '@/types/event'
 
 const kosugiMaru = Kosugi_Maru({subsets: ['latin'], weight: '400'})
 
 export default function RecentEvents() {
   const [signOpen, setSignOpen] = useState(false)
-  const [events, setEvents] = useState<Event[]>([])
+  const [events, setEvents] = useState<EventType[]>([])
 
   useEffect(() => {
-    getUpcomingEvents()
-      .then((data) => setEvents(data.docs))
+    getUpcomingEvents().then(setEvents)
   }, [])
 
   const eventNames = events.map((event) => event.title)
@@ -55,8 +54,7 @@ export default function RecentEvents() {
           >
             <div className="relative w-full max-w-[70%] md:max-w-[400px] h-auto">
               <Image
-                src={typeof event.image === 'object' && event.image?.url
-                  ? event.image.url : placeholderImage}
+                src={event.imageUrl}
                 alt={event.title}
                 width={400}
                 height={300}
@@ -64,7 +62,11 @@ export default function RecentEvents() {
               />
               <div
                 className="absolute top-0 left-0 bg-[#13384E] text-white px-5 py-3 text-lg font-semibold rounded-br-xl">
-                {new Date(event.date).toLocaleDateString('en-NZ', {day: 'numeric', month: 'long', year: 'numeric'})}
+                {event.date.toLocaleDateString('en-NZ', {
+                  day: 'numeric',
+                  month: 'long',
+                  year: 'numeric',
+                })}
               </div>
               {/* Decoration: red circle (first) or kiwi (second) */}
               {idx === 0 ? (
@@ -87,7 +89,7 @@ export default function RecentEvents() {
                 {event.title}
               </h2>
               <h3 className="text-base md:text-lg font-medium mb-4">
-                HOSTED BY: {Array.isArray(event.host) ? event.host.join(', ') : event.host}
+                HOSTED BY: {event.hostedBy}
               </h3>
               <p className={`text-sm md:text-base leading-relaxed ${kosugiMaru.className}`}>
                 {event.description}

--- a/src/components/events/RecentEvents.tsx
+++ b/src/components/events/RecentEvents.tsx
@@ -1,33 +1,26 @@
 'use client'
-import { useState, useEffect } from 'react'
+import {useState, useEffect} from 'react'
 import Image from 'next/image'
 import SignUpModal from '@/components/events/EventsSignUpModal'
 import Koru from '@/assets/recent_events_koru.png'
-import PlaceholderImg from '@/assets/placeholder_img.png'
+import placeholderImage from '@/assets/groupPic.png'
 import KiwiBird from '@/assets/kiwiBird.svg'
-import { Kosugi_Maru } from 'next/font/google'
-const kosugiMaru = Kosugi_Maru({ subsets: ['latin'], weight: '400' })
+import {Kosugi_Maru} from 'next/font/google'
+import {getUpcomingEvents} from "@/lib/payload/events";
+import type {Event} from '@/payload-types'
+
+const kosugiMaru = Kosugi_Maru({subsets: ['latin'], weight: '400'})
 
 export default function RecentEvents() {
   const [signOpen, setSignOpen] = useState(false)
-  const [events, setEvents] = useState<EventType[]>([])
-
-  type EventType = {
-    id: string | number
-    name: string
-    hosted_by: string
-    description: string
-    date: string
-    image?: string
-  }
+  const [events, setEvents] = useState<Event[]>([])
 
   useEffect(() => {
-    fetch('/api/upcoming-events')
-      .then((res) => res.json())
-      .then((data) => setEvents(data.events))
+    getUpcomingEvents()
+      .then((data) => setEvents(data.docs))
   }, [])
 
-  const eventNames = events.map((event) => event.name)
+  const eventNames = events.map((event) => event.title)
 
   return (
     <>
@@ -43,7 +36,7 @@ export default function RecentEvents() {
       {/* Header Bar */}
       <div
         className="w-[45%] bg-[#13384E] rounded-t-2xl flex items-center justify-center"
-        style={{ height: '5rem' }}
+        style={{height: '5rem'}}
       >
         <h2 className="text-white text-base md:text-2xl lg:text-3xl font-semibold">
           UPCOMING EVENTS
@@ -53,7 +46,7 @@ export default function RecentEvents() {
       {/* Main Content */}
       <section
         className="relative w-full bg-[#13384E] px-6 pt-0 pb-8 overflow-x-hidden"
-        style={{ minHeight: '80rem' }}
+        style={{minHeight: '80rem'}}
       >
         {events.map((event, idx) => (
           <div
@@ -62,20 +55,24 @@ export default function RecentEvents() {
           >
             <div className="relative w-full max-w-[70%] md:max-w-[400px] h-auto">
               <Image
-                src={event.image || PlaceholderImg}
-                alt={event.name}
+                src={typeof event.image === 'object' && event.image?.url
+                  ? event.image.url : placeholderImage}
+                alt={event.title}
                 width={400}
                 height={300}
                 className="w-[400px] h-[300px] object-cover rounded-xl shadow-lg"
               />
-              <div className="absolute top-0 left-0 bg-[#13384E] text-white px-5 py-3 text-lg font-semibold rounded-br-xl">
-                {new Date(event.date).toLocaleDateString('en-NZ')}
+              <div
+                className="absolute top-0 left-0 bg-[#13384E] text-white px-5 py-3 text-lg font-semibold rounded-br-xl">
+                {new Date(event.date).toLocaleDateString('en-NZ', {day: 'numeric', month: 'long', year: 'numeric'})}
               </div>
               {/* Decoration: red circle (first) or kiwi (second) */}
               {idx === 0 ? (
-                <div className="absolute rounded-full bg-[#eb5454] w-8 h-8 bottom-[-16px] left-[-16px] md:w-15 md:h-15 md:bottom-[-20px] md:left-[-20px] lg:w-20 lg:h-20 lg:bottom-[-24px] lg:left-[-24px]" />
+                <div
+                  className="absolute rounded-full bg-[#eb5454] w-8 h-8 bottom-[-16px] left-[-16px] md:w-15 md:h-15 md:bottom-[-20px] md:left-[-20px] lg:w-20 lg:h-20 lg:bottom-[-24px] lg:left-[-24px]"/>
               ) : (
-                <div className="absolute bottom-[-16px] right-[-16px] md:bottom-[-20px] md:right-[-20px] lg:bottom-[-24px] lg:right-[-24px] w-8 h-8 md:w-15 md:h-15 lg:w-20 lg:h-20 flex items-center justify-center">
+                <div
+                  className="absolute bottom-[-16px] right-[-16px] md:bottom-[-20px] md:right-[-20px] lg:bottom-[-24px] lg:right-[-24px] w-8 h-8 md:w-15 md:h-15 lg:w-20 lg:h-20 flex items-center justify-center">
                   <Image
                     src={KiwiBird}
                     alt="Kiwi decoration"
@@ -87,10 +84,10 @@ export default function RecentEvents() {
 
             <div className="text-white max-w-xl">
               <h2 className={`text-2xl md:text-3xl font-semibold mb-2 ${kosugiMaru.className}`}>
-                {event.name}
+                {event.title}
               </h2>
               <h3 className="text-base md:text-lg font-medium mb-4">
-                HOSTED BY: {event.hosted_by}
+                HOSTED BY: {Array.isArray(event.host) ? event.host.join(', ') : event.host}
               </h3>
               <p className={`text-sm md:text-base leading-relaxed ${kosugiMaru.className}`}>
                 {event.description}
@@ -106,7 +103,7 @@ export default function RecentEvents() {
         ))}
       </section>
 
-      <SignUpModal signOpen={signOpen} setSignOpen={setSignOpen} eventOptions={eventNames} />
+      <SignUpModal signOpen={signOpen} setSignOpen={setSignOpen} eventOptions={eventNames}/>
     </>
   )
 }

--- a/src/lib/mapEvent.ts
+++ b/src/lib/mapEvent.ts
@@ -1,0 +1,17 @@
+import PlaceholderImg from '@/assets/event-pic.png'
+import type { Event } from '@/payload-types'
+import { EventType } from '@/types/event'
+
+export function mapPayloadEvent(e: Event): EventType {
+  return {
+    id: e.id,
+    title: e.title,
+    description: e.description ?? '',
+    date: new Date(e.date),
+    hostedBy: e.host?.join(', ') ?? 'Unknown host',
+    imageUrl:
+      typeof e.image === 'object' && e.image?.url
+        ? e.image.url
+        : PlaceholderImg,
+  }
+}

--- a/src/lib/payload/events.ts
+++ b/src/lib/payload/events.ts
@@ -1,29 +1,30 @@
-import { fetchJSON } from './client'
+import { mapPayloadEvent } from '@/lib/mapEvent'
+import { EventType } from '@/types/event'
 import type { Event } from '@/payload-types'
+import {fetchJSON} from "@/lib/payload/client";
 
 type Paginated<T> = {
-    docs: T[]
-    totalDocs: number
-    limit: number
-    page: number
-    totalPages: number
-    hasNextPage: boolean
-    hasPrevPage: boolean
-}
+    docs: T[];
+    totalDocs: number;
+    limit: number;
+    page: number;
+    totalPages: number;
+    hasNextPage: boolean;
+    hasPrevPage: boolean;
+};
 
-export async function getUpcomingEvents() {
+export async function getUpcomingEvents(): Promise<EventType[]> {
     const now = new Date().toISOString()
-
-    return fetchJSON<Paginated<Event>>(
-        `/api/events?where[date][greater_than]=${encodeURIComponent(now)}&sort=date&limit=5`
+    const data = await fetchJSON<Paginated<Event>>(
+      `/api/events?where[date][greater_than]=${encodeURIComponent(now)}&sort=date&limit=5&depth=2`
     )
+    return data.docs.map(mapPayloadEvent)
 }
 
-export async function getPastEvents() {
+export async function getPastEvents(): Promise<EventType[]> {
     const now = new Date().toISOString()
-
-    return fetchJSON<Paginated<Event>>(
-        `/api/events?where[date][less_than]=${encodeURIComponent(now)}&sort=date&limit=0`
+    const data = await fetchJSON<Paginated<Event>>(
+      `/api/events?where[date][less_than]=${encodeURIComponent(now)}&sort=date&limit=0&depth=2`
     )
+    return data.docs.map(mapPayloadEvent)
 }
-

--- a/src/lib/payload/events.ts
+++ b/src/lib/payload/events.ts
@@ -1,0 +1,29 @@
+import { fetchJSON } from './client'
+import type { Event } from '@/payload-types'
+
+type Paginated<T> = {
+    docs: T[]
+    totalDocs: number
+    limit: number
+    page: number
+    totalPages: number
+    hasNextPage: boolean
+    hasPrevPage: boolean
+}
+
+export async function getUpcomingEvents() {
+    const now = new Date().toISOString()
+
+    return fetchJSON<Paginated<Event>>(
+        `/api/events?where[date][greater_than]=${encodeURIComponent(now)}&sort=date&limit=5`
+    )
+}
+
+export async function getPastEvents() {
+    const now = new Date().toISOString()
+
+    return fetchJSON<Paginated<Event>>(
+        `/api/events?where[date][less_than]=${encodeURIComponent(now)}&sort=date&limit=0`
+    )
+}
+

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -200,7 +200,7 @@ export interface Event {
   id: string;
   title: string;
   description?: string | null;
-  date?: string | null;
+  date: string;
   venue?: string | null;
   image?: (string | null) | Media;
   published?: boolean | null;

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -1,0 +1,11 @@
+import type { StaticImageData } from 'next/image'
+
+export type EventType = {
+  id: string
+  title: string
+  hostedBy: string
+  description: string
+  date: Date
+  venue?: string
+  imageUrl: string | StaticImageData
+}


### PR DESCRIPTION
## Describe the issue

- Adding/removing events was throwing a Method Not Allowed error due to custom /api/events route was overshadowing Payload's auto-generated endpoint
- Multiple EventType interfaces were defined across the codebase, making it hard to maintain
- Inconsistent event model: Some places used date_range, others date, and image handling was inconsistent
- page.tsx for Events page was marked as 'use client' unnecessarily
- SignUpModal and PastEventPopUpModal were instantiated in page.tsx while also being controlled in their own components. 

## Describe the solution

- Event addition/removal works as intended
- API calls now live in the page
- Added shared EventType and mapPayloadEvent adapter

## Risk

- This refactor touches many components; not fully tested yet

## Definition of Done

- [ ] Code peer-reviewed
- [ ] Wiki Documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

Who reviewed your PR - for commit history once merged
