### PR TITLE
HT-112/Manage and Display "Meet the Team" Section via Payload CMS 

### DIFF
--- a/src/collections/Members.ts
+++ b/src/collections/Members.ts
@@ -1,0 +1,43 @@
+import { isEditorOrAdmin } from '@/access/UserAccess'
+import type { CollectionConfig } from 'payload'
+
+export const Member: CollectionConfig = {
+  slug: 'member',
+
+  admin: {
+    useAsTitle: 'name',
+  },
+  access: {
+    read: () => true,
+    create: isEditorOrAdmin,
+    update: isEditorOrAdmin,
+    delete: isEditorOrAdmin,
+  },
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'image',
+      type: 'relationship',
+      relationTo: 'media',
+    },
+    {
+      name: 'role',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'gender',
+      type: 'select',
+      defaultValue: 'other',
+      options: [
+        { label: '(he/him)', value: 'male' },
+        { label: '(she/her)', value: 'female' },
+        { label: 'Other', value: 'other' },
+      ],
+    },
+  ],
+}

--- a/src/collections/Members.ts
+++ b/src/collections/Members.ts
@@ -2,7 +2,7 @@ import { isEditorOrAdmin } from '@/access/UserAccess'
 import type { CollectionConfig } from 'payload'
 
 export const Member: CollectionConfig = {
-  slug: 'member',
+  slug: 'members',
 
   admin: {
     useAsTitle: 'name',
@@ -30,12 +30,12 @@ export const Member: CollectionConfig = {
       required: true,
     },
     {
-      name: 'gender',
+      name: 'pronoun',
       type: 'select',
       defaultValue: 'other',
       options: [
-        { label: '(he/him)', value: 'male' },
-        { label: '(she/her)', value: 'female' },
+        { label: '(he/him)', value: '(he/him)' },
+        { label: '(she/her)', value: '(she/her)' },
         { label: 'Other', value: 'other' },
       ],
     },

--- a/src/components/AboutUs/MeetTheTeam.tsx
+++ b/src/components/AboutUs/MeetTheTeam.tsx
@@ -1,59 +1,60 @@
 import Image, { StaticImageData } from 'next/image'
-import profilePic from '@/assets/personPicture.png'
+import placeholderImage from '@/assets/personPicture.png'
 import koru from '@/assets/bigGreenKoru.png'
 import kiwi from '@/assets/kiwiBird.svg'
 import induBajwaPic from '@/assets/indu-bajwa-upscaled-profile.png'
 import amanGillPic from '@/assets/aman-gill-upscaled-profile.jpeg'
 import { getMembers } from '@/lib/payload/members'
 import { profileEnd } from 'console'
+import { url } from 'inspector'
 
 interface MemberProp {
   name: string
   pronoun: string
   role: string
-  imageUrl: string | StaticImageData | null | undefined
+  imageUrl: string | StaticImageData
   slug?: string
 }
 
 export default async function MeetTheTeam() {
-  const peopleArray = [
-    {
-      name: 'Esther Ho',
-      pronoun: '(she/her)',
-      role: 'Chairperson',
-      image: profilePic,
-    },
-    {
-      name: 'Aman Gill',
-      pronoun: '(she/her)',
-      role: 'Trustees',
-      image: amanGillPic,
-    },
-    {
-      name: 'Christine Knock',
-      pronoun: '(she/her)',
-      role: 'Trustees',
-      image: profilePic,
-    },
-    {
-      name: 'Indu Bajwa',
-      pronoun: '(she/her)',
-      role: 'Manager',
-      image: induBajwaPic,
-    },
-    {
-      name: 'Divya Niyyar',
-      pronoun: '(she/her)',
-      role: 'Coordinator',
-      image: profilePic,
-    },
-    {
-      name: 'Summit Niyar',
-      pronoun: '(he/him)',
-      role: 'Events & Volunteer Coordinator',
-      image: profilePic,
-    },
-  ]
+  // const peopleArray = [
+  //   {
+  //     name: 'Esther Ho',
+  //     pronoun: '(she/her)',
+  //     role: 'Chairperson',
+  //     image: profilePic,
+  //   },
+  //   {
+  //     name: 'Aman Gill',
+  //     pronoun: '(she/her)',
+  //     role: 'Trustees',
+  //     image: amanGillPic,
+  //   },
+  //   {
+  //     name: 'Christine Knock',
+  //     pronoun: '(she/her)',
+  //     role: 'Trustees',
+  //     image: profilePic,
+  //   },
+  //   {
+  //     name: 'Indu Bajwa',
+  //     pronoun: '(she/her)',
+  //     role: 'Manager',
+  //     image: induBajwaPic,
+  //   },
+  //   {
+  //     name: 'Divya Niyyar',
+  //     pronoun: '(she/her)',
+  //     role: 'Coordinator',
+  //     image: profilePic,
+  //   },
+  //   {
+  //     name: 'Summit Niyar',
+  //     pronoun: '(he/him)',
+  //     role: 'Events & Volunteer Coordinator',
+  //     image: profilePic,
+  //   },
+  // ]
 
   const members = await getMembers()
 
@@ -90,7 +91,11 @@ export default async function MeetTheTeam() {
               name={member.name}
               pronoun={member.pronoun ?? ''}
               role={member.role}
-              imageUrl={profilePic}
+              imageUrl={
+                typeof member.image === 'object' && member.image?.url
+                  ? member.image.url
+                  : placeholderImage
+              }
             />
           ))}
         </div>

--- a/src/components/AboutUs/MeetTheTeam.tsx
+++ b/src/components/AboutUs/MeetTheTeam.tsx
@@ -4,8 +4,18 @@ import koru from '@/assets/bigGreenKoru.png'
 import kiwi from '@/assets/kiwiBird.svg'
 import induBajwaPic from '@/assets/indu-bajwa-upscaled-profile.png'
 import amanGillPic from '@/assets/aman-gill-upscaled-profile.jpeg'
+import { getMembers } from '@/lib/payload/members'
+import { profileEnd } from 'console'
 
-export default function MeetTheTeam() {
+interface MemberProp {
+  name: string
+  pronoun: string
+  role: string
+  imageUrl: string | StaticImageData | null | undefined
+  slug?: string
+}
+
+export default async function MeetTheTeam() {
   const peopleArray = [
     {
       name: 'Esther Ho',
@@ -45,6 +55,8 @@ export default function MeetTheTeam() {
     },
   ]
 
+  const members = await getMembers()
+
   return (
     <div className="relative mb-[6rem] md:mb-[8rem]">
       {/* whole section */}
@@ -72,13 +84,13 @@ export default function MeetTheTeam() {
         {/* whole grid */}
 
         <div className="mt-[4vw] grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-3 gap-[10vw] px-[5vw]">
-          {peopleArray.map((person) => (
+          {members.map((member) => (
             <TeamMember
-              key={person.name}
-              name={person.name}
-              pronoun={person.pronoun}
-              role={person.role}
-              image={person.image}
+              key={member.id}
+              name={member.name}
+              pronoun={member.pronoun ?? ''}
+              role={member.role}
+              imageUrl={profilePic}
             />
           ))}
         </div>
@@ -87,23 +99,13 @@ export default function MeetTheTeam() {
   )
 }
 
-function TeamMember({
-  name,
-  pronoun,
-  role,
-  image,
-}: {
-  name: string
-  pronoun: string
-  role: string
-  image: StaticImageData
-}) {
+function TeamMember({ name, pronoun, role, imageUrl }: MemberProp) {
   return (
     <div className="flex flex-col items-center text-center">
       {/* image */}
 
       <div className="relative w-[clamp(4rem,20vw,10rem)] aspect-[4/5] overflow-hidden border-2 border-current rounded-md">
-        <Image src={image} alt={`${name}'s photo`} fill className="object-cover object-top" />
+        <Image src={imageUrl} alt={`${name}'s photo`} fill className="object-cover object-top" />
       </div>
 
       {/* text stuff */}

--- a/src/lib/payload/members.ts
+++ b/src/lib/payload/members.ts
@@ -1,0 +1,20 @@
+import { fetchJSON } from './client'
+import type { Member } from '@/payload-types'
+
+type PaginatedResponse = {
+  docs: Member[]
+  totalDocs: number
+  limit: number
+  totalPages: number
+  page: number
+  pagingCounter: number
+  hasPrevPage: boolean
+  hasNextPage: boolean
+  prevPage: number | null
+  nextPage: number | null
+}
+
+export async function getMembers() {
+  const data = await fetchJSON<PaginatedResponse>('/api/members?depth=2&sort=order&limit=100')
+  return data.docs
+}

--- a/src/lib/payload/members.ts
+++ b/src/lib/payload/members.ts
@@ -15,6 +15,6 @@ type PaginatedResponse = {
 }
 
 export async function getMembers() {
-  const data = await fetchJSON<PaginatedResponse>('/api/members?depth=2&sort=order&limit=100')
+  const data = await fetchJSON<PaginatedResponse>('/api/members?depth=2&sort=createdAt&limit=100')
   return data.docs
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -71,7 +71,7 @@ export interface Config {
     media: Media;
     blogs: Blog;
     events: Event;
-    member: Member;
+    members: Member;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
@@ -82,7 +82,7 @@ export interface Config {
     media: MediaSelect<false> | MediaSelect<true>;
     blogs: BlogsSelect<false> | BlogsSelect<true>;
     events: EventsSelect<false> | EventsSelect<true>;
-    member: MemberSelect<false> | MemberSelect<true>;
+    members: MembersSelect<false> | MembersSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
@@ -220,14 +220,14 @@ export interface Event {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "member".
+ * via the `definition` "members".
  */
 export interface Member {
   id: string;
   name: string;
   image?: (string | null) | Media;
   role: string;
-  gender?: ('male' | 'female' | 'other') | null;
+  pronoun?: ('(he/him)' | '(she/her)' | 'other') | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -255,7 +255,7 @@ export interface PayloadLockedDocument {
         value: string | Event;
       } | null)
     | ({
-        relationTo: 'member';
+        relationTo: 'members';
         value: string | Member;
       } | null);
   globalSlug?: string | null;
@@ -376,13 +376,13 @@ export interface EventsSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "member_select".
+ * via the `definition` "members_select".
  */
-export interface MemberSelect<T extends boolean = true> {
+export interface MembersSelect<T extends boolean = true> {
   name?: T;
   image?: T;
   role?: T;
-  gender?: T;
+  pronoun?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -71,6 +71,7 @@ export interface Config {
     media: Media;
     blogs: Blog;
     events: Event;
+    member: Member;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
@@ -81,6 +82,7 @@ export interface Config {
     media: MediaSelect<false> | MediaSelect<true>;
     blogs: BlogsSelect<false> | BlogsSelect<true>;
     events: EventsSelect<false> | EventsSelect<true>;
+    member: MemberSelect<false> | MemberSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
@@ -218,6 +220,19 @@ export interface Event {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "member".
+ */
+export interface Member {
+  id: string;
+  name: string;
+  image?: (string | null) | Media;
+  role: string;
+  gender?: ('male' | 'female' | 'other') | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
@@ -238,6 +253,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'events';
         value: string | Event;
+      } | null)
+    | ({
+        relationTo: 'member';
+        value: string | Member;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -352,6 +371,18 @@ export interface EventsSelect<T extends boolean = true> {
   image?: T;
   published?: T;
   host?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "member_select".
+ */
+export interface MemberSelect<T extends boolean = true> {
+  name?: T;
+  image?: T;
+  role?: T;
+  gender?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -11,6 +11,7 @@ import { Users } from './collections/Users'
 import { Media } from './collections/Media'
 import { Blogs } from './collections/Blogs'
 import { Events } from './collections/Events'
+import { Member } from './collections/Members'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -22,7 +23,7 @@ export default buildConfig({
       baseDir: path.resolve(dirname),
     },
   },
-  collections: [Users, Media, Blogs, Events],
+  collections: [Users, Media, Blogs, Events, Member],
   editor: lexicalEditor(),
   secret: process.env.PAYLOAD_SECRET || '',
   typescript: {


### PR DESCRIPTION
## Describe the issue

The Meet the team section was static 

## Describe the solution

Implemented a solution to store and manage team member data (images, names, roles) within Payload CMS. The frontend is updated to dynamically fetch and display this data from the Payload API.

## Risk

No risk that I can think of.

## Definition of Done

- [ ] Code peer-reviewed
- [ ] Wiki Documentation is written and up to date
- [ ] Unit tests written and passing
- [ ] Integration tests written and passing
- [ ] Continuous Integration build passing
- [ ] Acceptance criteria met
- [ ] Deployed to production environment

## Reviewed By

Who reviewed your PR - for commit history once merged
